### PR TITLE
Expose password entry

### DIFF
--- a/item.go
+++ b/item.go
@@ -214,6 +214,10 @@ func (id *ItemDetail) Fields() []*Field {
 	return fields
 }
 
+func (id *ItemDetail) Password() string {
+	return id.data.getString("password")
+}
+
 func (id *ItemDetail) Notes() string {
 	return id.data.getString("notesPlain")
 }


### PR DESCRIPTION
Currently, there is no way to grab the password from _password_ type entries in 1Password as far as I can tell. This function exposes them.

The naming could be a little misleading since it appears to only be populated for _password_ type entries and not others like _login_ (since they're populated in the `Field` type instead).